### PR TITLE
Update pre-check trigger

### DIFF
--- a/.github/workflows/pub_pre_check.yml
+++ b/.github/workflows/pub_pre_check.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   publish_to_pub_pre_check:
     name: Publish to Pub pre-check
+    if: contains(github.event.pull_request.labels.*.name, 'release :tada:')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code


### PR DESCRIPTION
pub_pre_check's caller workflows should now use a `pull_request` or `pull_request_target` trigger with 'synchronize' and 'labeled' types.