### PR TITLE
Update pub release logic

### DIFF
--- a/.github/workflows/pub_release.yml
+++ b/.github/workflows/pub_release.yml
@@ -4,9 +4,10 @@
 #   group: Release to Pub
 #   cancel-in-progress: true
 #
-# - Enable 'write' permission for 'contents'
+# - Enable 'write' permission for 'contents' and 'id-token'
 # permissions:
 #   contents: write
+#   id-token: write
 #
 # Additional setup: The changelog for Github Release is generated from the CHANGELOG.md file.
 # To add more details, refer to https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
@@ -25,17 +26,6 @@ on:
       job_name:
         required: false
         type: string
-    secrets:
-      PUB_CREDENTIALS_ACCESS_TOKEN:
-        required: true
-      PUB_CREDENTIALS_REFRESH_TOKEN:
-        required: true
-      PUB_CREDENTIALS_ID_TOKEN:
-        required: true
-      PUB_CREDENTIALS_TOKEN_ENDPOINT:
-        required: true
-      PUB_CREDENTIALS_EXPIRATION:
-        required: true
 
 jobs:
   release:
@@ -82,16 +72,15 @@ jobs:
           running-workflow-name: '${{ inputs.job_name }} / Release and Publish Package'
           allowed-conclusions: success,skipped
 
-      - name: Release package
+      - name: Release package (Github)
         if: success()
-        timeout-minutes: 30
         uses: sidrao2006/release-pub-package@main
-        with:
-          pre-publish-command: flutter format .
-          access-token: ${{ secrets.PUB_CREDENTIALS_ACCESS_TOKEN }}
-          refresh-token: ${{ secrets.PUB_CREDENTIALS_REFRESH_TOKEN }}
-          id-token: ${{ secrets.PUB_CREDENTIALS_ID_TOKEN }}
-          token-endpoint: ${{ secrets.PUB_CREDENTIALS_TOKEN_ENDPOINT }}
-          expiration: ${{ secrets.PUB_CREDENTIALS_EXPIRATION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish package to pub.dev
+        if: success()
+        timeout-minutes: 30
+        uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1.6.4
+        with:
+          environment: ${{ inputs.environment }}


### PR DESCRIPTION
pub.dev now uses OIDC for auth
See https://dart.dev/tools/pub/automated-publishing#triggering-automated-publishing-from-github-actions
Update includes changes made in release-pub-package action->
sidrao2006/release-pub-package@49232983a1019f06ce8e46e2d9b04390c20511d2

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

Yes

I have modified or deleted the following public APIs which will break the users' code - 
  1. Removed auth input fields