### PR TITLE
Replace workflow call with custom code

### DIFF
--- a/.github/workflows/pub_release.yml
+++ b/.github/workflows/pub_release.yml
@@ -87,6 +87,6 @@ jobs:
       - name: Publish package to pub.dev
         if: success()
         timeout-minutes: 30
-        uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1.6.4
-        with:
-          environment: ${{ inputs.environment }}
+        run: |
+          dart pub get
+          dart pub publish


### PR DESCRIPTION
Reusable workflows can't be referenced within steps -> Added custom code to publish package instead of relying on external reusable workflow

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
